### PR TITLE
FIX Update `client_id` and `client_secret` in Helm charts

### DIFF
--- a/helm-charts/main.tf
+++ b/helm-charts/main.tf
@@ -75,8 +75,8 @@ resource "helm_release" "unionai_dataplane" {
       org_name             = var.org_name
       bucket_name          = data.terraform_remote_state.infrastructure.outputs.s3_bucket_name
       region               = data.terraform_remote_state.infrastructure.outputs.region
-      client_id            = data.terraform_remote_state.infrastructure.outputs.s3_access_key_id
-      client_secret        = data.terraform_remote_state.infrastructure.outputs.s3_secret_access_key
+      client_id            = var.client_id
+      client_secret        = var.client_secret
       union_flyte_role_arn = data.terraform_remote_state.infrastructure.outputs.union_flyte_role_arn
     })
   ]

--- a/helm-charts/variables.tf
+++ b/helm-charts/variables.tf
@@ -3,3 +3,13 @@ variable "org_name" {
   type        = string
   default     = "amazon"
 }
+
+variable "client_id" {
+  description = "Union client ID for Helm chart"
+  type        = string
+}
+
+variable "client_secret" {
+  description = "Union client secret for Helm chart"
+  type        = string
+}


### PR DESCRIPTION
This PR modifies the `client_id` and `client_secret` fields to be user-provided.

Reference:

See <i>Step 2</i> in https://www.union.ai/docs/v2/selfmanaged/deployment/byok-data-plane-setup-on-aws/